### PR TITLE
Export types, fix output

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,21 +162,21 @@ func handleTypeDef(ts ast.TypeSpec) {
 	// type MyAlias string
 	// type MyAlias2 AnotherType
 	case *ast.Ident:
-		fmt.Printf("type %s = %s;\n\n", ts.Name, GetTypeInfo(t))
+		fmt.Printf("export type %s = %s;\n\n", ts.Name, GetTypeInfo(t))
 		return
 	// type MyAlias []AnotherType
 	case *ast.ArrayType:
 		elementType := GetTypeInfo(t.Elt)
-		fmt.Printf("type %s = Array<%s>;\n\n", ts.Name, elementType)
+		fmt.Printf("export type %s = Array<%s>;\n\n", ts.Name, elementType)
 		return
 	// type MyAlias map[boolean]AnotherType
 	case *ast.MapType:
 		keyType := GetTypeInfo(t.Key)
 		valueType := GetTypeInfo(t.Value)
-		fmt.Printf("type %s = {[%s]: %s};\n\n", ts.Name, keyType, valueType)
+		fmt.Printf("export type %s = {[%s]: %s};\n\n", ts.Name, keyType, valueType)
 		return
 	case *ast.StructType:
-		fmt.Printf("type %s {\n", ts.Name)
+		fmt.Printf("export type %s = {\n", ts.Name)
 		fields := t.Fields.List
 		for _, field := range fields {
 			handleField(*field)


### PR DESCRIPTION
# Changes
- [x] Add `export` to the types (we could make this configurable in the future)
- [x] Bugfix: add an `=` after the type declaration in the flow output for Struct Types

# Before
```golang
type Tuple {
  name: string,
  label: string,
}

type JiraLink {
  name: string,
  label: string,
  created_at: string,
}

type VendorAgreement {
  html: string,
}

type S3UploadURLResponse {
  url: string,
  path: string,
}

type S3UploadRequest {
  md5: string,
  file_name: string,
  folder: string,
}
```


# After

```golang
export type Tuple = {
  name: string,
  label: string,
}

export type JiraLink = {
  name: string,
  label: string,
  created_at: string,
}

export type VendorAgreement = {
  html: string,
}

export type S3UploadURLResponse = {
  url: string,
  path: string,
}

export type S3UploadRequest = {
  md5: string,
  file_name: string,
  folder: string,
}
```