### PR TITLE
deliver go2flow binaries with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.8.3-alpine
+
+WORKDIR /go/src/github.com/kristiehoward/go2flow
+COPY . /go/src/github.com/kristiehoward/go2flow
+
+RUN CGO_ENABLED=0 go install -v -ldflags="-s" && \
+	GOOS=linux GOARCH=s390x  go install -v -ldflags="-s" && \
+	GOOS=linux GOARCH=ppc64le  go install -v -ldflags="-s" && \
+	GOOS=darwin GOARCH=amd64 go install -v -ldflags="-s" && \
+	GOOS=windows GOARCH=amd64 go install -v -ldflags="-s"
+
+
+FROM alpine:3.6
+
+RUN apk --no-cache add ca-certificates
+
+COPY --from=0 /go/bin/go2flow /go2flow-Linux-x86_64
+COPY --from=0 /go/bin/linux_s390x/go2flow /go2flow-Linux-s390x
+COPY --from=0 /go/bin/linux_ppc64le/go2flow /go2flow-Linux-ppc64le
+COPY --from=0 /go/bin/darwin_amd64/go2flow /go2flow-Darwin-x86_64
+COPY --from=0 /go/bin/windows_amd64/go2flow.exe /go2flow-Windows-x86_64
+
+RUN ln -s /go2flow-Linux-x86_64 /usr/local/bin/go2flow
+
+ENTRYPOINT ["go2flow"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
 
 It relies on the [JSON encoding](https://golang.org/pkg/encoding/json/) of a Go struct (defined in struct field tags), generating Flow type definitions to be used in the consumer's JS code base.
 
+# Getting go2flow
+
+On Linux and macOS, this command will copy the go2flow executable to your current working directory:
+
+```bash
+$ docker pull kristiehoward/go2flow:latest &&
+    id=$(docker create kristiehoward/go2flow:latest) &&
+    docker cp $id:/go2flow-$(uname -s)-$(uname -m) go2flow &&
+    (docker rm $id >/dev/null)
+```
+
+On windows
+
+```bash
+$ docker pull kristiehoward/go2flow:latest &&
+    id=$(docker create kristiehoward/go2flow:latest) &&
+    docker cp $id:/go2flow-Windows-x86_64 go2flow.exe &&
+    (docker rm $id >/dev/null)
+```
+
+Run `./go2flow -h` or `./go2flow --help` to print usage.
+
 # Development
 
 Run the Proof of Concept on the sample file
@@ -26,7 +48,7 @@ go test
 - [ ] More sample files
 - [ ] Test output (return a string instead of printing)
 - [ ] Document the decisions made for translation from Go type --> JSON output --> Flow definition
-- [ ] Accept CLI args
+- [x] Accept CLI args
 
 
 # Rules


### PR DESCRIPTION
This PR adds a `Dockerfile` to build and ship go2flow binaries